### PR TITLE
Process plotting for ROC binaries

### DIFF
--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -22,6 +22,7 @@ variables:
     Inputs: baseline
     DataDir: ./
     Dataset: All200.root
+    Signal: "VBFHtt" # add interessting signal procs here in process_labels() in tagger/plot/basic.py
 
 .template:
   image: gitlab-registry.cern.ch/cebrown/docker-images/mamba_jettagger:latest
@@ -51,7 +52,7 @@ data:
   - cd data
   - mc cp $ARTIFACTS_ALIAS/$ARTIFACTS_BUCKET/$DataDir/$Dataset ./
   - cd ..
-  - python tagger/train/train.py --make-data -i data/$Dataset
+  - python tagger/train/train.py --make-data -i data/$Dataset -sig $Signal
   - tar -cf training_data_$Inputs.tgz training_data
   - mc cp training_data_$Inputs.tgz $ARTIFACTS_ALIAS/$ARTIFACTS_BUCKET/$DataDir
 
@@ -59,7 +60,7 @@ train:
   extends:
     - .template
   stage: train
-  needs: 
+  needs:
     - job : data
       optional: true
   script:
@@ -67,7 +68,7 @@ train:
   - tar -xf training_data_$Inputs.tgz
   - source activate tagger
   - python tagger/train/train.py -n $Name
-  - python tagger/train/train.py --plot-basic -n $Name
+  - python tagger/train/train.py --plot-basic -n $Name -sig $Signal
   - cd output/baseline
   - tar -cf testing_data_$Inputs.tgz testing_data
   - mc cp testing_data_$Inputs.tgz $ARTIFACTS_ALIAS/$ARTIFACTS_BUCKET/$DataDir
@@ -203,7 +204,7 @@ upload:
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.cern.ch/cms-analysis/general/php-plots.git -b feature/update_extension_grouping
     - export PATH="${PATH}:/builds/ml_l1/php-plots/bin"
     - pb_copy_index.py TrainTagger/${Name} --recursive
-    - pb_deploy_plots.py TrainTagger/${Name} /eos/user/c/cebrown/www/JetTagging/${CI_PROJECT_NAME}/${CI_COMMIT_REF_NAME} --recursive --extensions h5,cpp,h,yml,tcl,sh,png,pdf,rpt 
+    - pb_deploy_plots.py TrainTagger/${Name} /eos/user/c/cebrown/www/JetTagging/${CI_PROJECT_NAME}/${CI_COMMIT_REF_NAME} --recursive --extensions h5,cpp,h,yml,tcl,sh,png,pdf,rpt
   artifacts:
     paths:
       - $Name

--- a/tagger/train/train.py
+++ b/tagger/train/train.py
@@ -18,7 +18,7 @@ from datetime import datetime
 # GLOBAL PARAMETERS TO BE DEFINED WHEN TRAINING
 tf.keras.utils.set_random_seed(420) #not a special number
 BATCH_SIZE = 1024
-EPOCHS = 10
+EPOCHS = 100
 VALIDATION_SPLIT = 0.1 # 10% of training set will be used for validation set.
 
 # Sparsity parameters
@@ -192,7 +192,7 @@ if __name__ == "__main__":
 
     #Making input arguments
     parser.add_argument('--make-data', action='store_true', help='Prepare the data if set.')
-    parser.add_argument('-i','--input', default='/eos/cms/store/cmst3/group/l1tr/sewuchte/l1teg/fp_ntuples_v131Xv9/extendedTRK_5param_221124/All200_part0.root' , help = 'Path to input training data')
+    parser.add_argument('-i','--input', default='/eos/cms/store/cmst3/group/l1tr/sewuchte/l1teg/fp_ntuples_v131Xv9/extendedTRK_5param_221124/All200.root' , help = 'Path to input training data')
     parser.add_argument('-r','--ratio', default=1, type=float, help = 'Ratio (0-1) of the input data root file to process')
     parser.add_argument('-s','--step', default='100MB' , help = 'The maximum memory size to process input root file')
     parser.add_argument('-e','--extras', default='extra_fields', help= 'Which extra fields to add to output tuples, defined in pfcand_fields.yml')

--- a/tagger/train/train.py
+++ b/tagger/train/train.py
@@ -192,7 +192,6 @@ if __name__ == "__main__":
 
     #Making input arguments
     parser.add_argument('--make-data', action='store_true', help='Prepare the data if set.')
-    parser.add_argument('--make-signal-data', action='store_true', help='Prepare the signal data required for plotting.')
     parser.add_argument('-i','--input', default='/eos/cms/store/cmst3/group/l1tr/sewuchte/l1teg/fp_ntuples_v131Xv9/extendedTRK_5param_221124/All200.root' , help = 'Path to input training data')
     parser.add_argument('-r','--ratio', default=1, type=float, help = 'Ratio (0-1) of the input data root file to process')
     parser.add_argument('-s','--step', default='100MB' , help = 'The maximum memory size to process input root file')
@@ -216,9 +215,6 @@ if __name__ == "__main__":
     if args.make_data:
         make_data(infile=args.input, step_size=args.step, extras=args.extras, ratio=args.ratio) #Write to training_data/, can be specified using outdir, but keeping it simple here for now
 
-    elif args.make_signal_data:
-        if not args.signal_processes:
-            raise ValueError("No signal processes specified for making signal data.")
         # Format all the signal processes used for plotting later
         for signal_process in args.signal_processes:
             signal_input = os.path.join(os.path.dirname(args.input), f"{signal_process}.root")


### PR DESCRIPTION
Added a function to filter on signal specific jets in test set. Done through a comparison of the test set and the signal set. Signal jets must be processed in the same fashion as the test set (make_data, load_data and to_ML). The signal data is created along the with the training data using --make-data and -sig (list of signal files) to specify which signal are of interest for plotting. The filtering is done in filter_processes through np.unique to identify the correct jets through the counts.