### PR TITLE
15 1 migration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,8 +47,8 @@ DeepSet:baseline_5param:
      EOS_STORAGE_SUBDIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/pipeline${CI_PIPELINE_ID}
      EOS_STORAGE_DATADIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/TrainingFiles
      SCRAM_ARCH: 'el9_amd64_gcc12'
-     CMSSW_VERSION: 'CMSSW_14_2_0_pre2'
-     CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:14_2_pre2_L1TSC4NGJetTagger'
+     CMSSW_VERSION: 'CMSSW_15_1_0_pre1'
+     CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:15_1_pre1_L1TSC4NGJetTagger'
 
 DeepSet:baseline_4param_extended_trk:
   extends: .ml_pipeline
@@ -68,8 +68,8 @@ DeepSet:baseline_4param_extended_trk:
      EOS_STORAGE_SUBDIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/pipeline${CI_PIPELINE_ID}
      EOS_STORAGE_DATADIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/TrainingFiles
      SCRAM_ARCH: 'el9_amd64_gcc12'
-     CMSSW_VERSION: 'CMSSW_14_2_0_pre2'
-     CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:14_2_pre2_L1TSC4NGJetTagger'
+     CMSSW_VERSION: 'CMSSW_15_1_0_pre1'
+     CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:15_1_pre1_L1TSC4NGJetTagger'
 
 DeepSet:baseline_5param_extended_trk:
   extends: .ml_pipeline
@@ -89,8 +89,8 @@ DeepSet:baseline_5param_extended_trk:
      EOS_STORAGE_SUBDIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/pipeline${CI_PIPELINE_ID}
      EOS_STORAGE_DATADIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/TrainingFiles
      SCRAM_ARCH: 'el9_amd64_gcc12'
-     CMSSW_VERSION: 'CMSSW_14_2_0_pre2'
-     CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:14_2_pre2_L1TSC4NGJetTagger'
+     CMSSW_VERSION: 'CMSSW_15_1_0_pre1'
+     CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:15_1_pre1_L1TSC4NGJetTagger'
 
 DeepSet:new_samples_baseline_5param_extended_trk:
   extends: .ml_pipeline
@@ -110,5 +110,5 @@ DeepSet:new_samples_baseline_5param_extended_trk:
     EOS_STORAGE_SUBDIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/pipeline${CI_PIPELINE_ID}
     EOS_STORAGE_DATADIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/TrainingFiles
     SCRAM_ARCH: 'el9_amd64_gcc12'
-    CMSSW_VERSION: 'CMSSW_14_2_0_pre2'
-    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:14_2_pre2_L1TSC4NGJetTagger'
+    CMSSW_VERSION: 'CMSSW_15_1_0_pre1'
+    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:15_1_pre1_L1TSC4NGJetTagger'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,9 @@ include:
   - local: "CI/template.yml"
 
 # Name = Name of child pipeline
-# Inputs = Which input configuration to ise
+# Inputs = Which input configuration to use
+# N_PARAMS = Number of tracking parameters for the track fit
+# TRACK_ALGO = Tracking Algorithm, baseline or extended
 # TRAIN = Which dataset to use for training
 # MINBIAS = Which MinBias to use for rate calculations
 # BBBB = Which dataset to use for HH->BBBB efficiency studies
@@ -16,6 +18,8 @@ DeepSet:baseline_4param:
    variables:
      Name: baseline_4param
      Inputs: baseline
+     N_PARAMS: 4
+     TRACK_ALGO: baseline
      TRAIN: All200.root
      MINBIAS: MinBias_PU200.root
      BBBB: ggHHbbbb_PU200.root
@@ -34,6 +38,8 @@ DeepSet:baseline_5param:
    variables:
      Name: baseline_5param
      Inputs: baseline
+     N_PARAMS: 5
+     TRACK_ALGO: baseline
      TRAIN: All200.root
      MINBIAS: MinBias_PU200.root
      BBBB: ggHHbbbb_PU200.root
@@ -55,6 +61,8 @@ DeepSet:baseline_4param_extended_trk:
   variables:
      Name: baseline_4param_extended_trk
      Inputs: baseline
+     N_PARAMS: 4
+     TRACK_ALGO: extended
      TRAIN: All200.root
      MINBIAS: MinBias_PU200.root
      BBBB: ggHHbbbb_PU200.root
@@ -76,6 +84,8 @@ DeepSet:baseline_5param_extended_trk:
   variables:
      Name: baseline_5param_extended_trk
      Inputs: baseline
+     N_PARAMS: 5
+     TRACK_ALGO: extended
      TRAIN: All200.root
      MINBIAS: MinBias_PU200.root
      BBBB:  ggHHbbbb_PU200.root
@@ -97,6 +107,8 @@ DeepSet:new_samples_baseline_5param_extended_trk:
   variables:
     Name: new_samples_baseline_5param_extended_trk
     Inputs: baseline
+    N_PARAMS: 5
+    TRACK_ALGO: extended
     TRAIN: All200.root
     MINBIAS: MinBias_PU200.root
     BBBB: GluGluHHTo4B_PU200.root

--- a/CI/cmssw.yml
+++ b/CI/cmssw.yml
@@ -16,6 +16,6 @@ emulate:
   artifacts:
     when: always
     paths:
-      - ${CMSSW_VERSION}/src/FastPUPPI/NtupleProducer/python/jetTuple_extended_5.root
+      - ${CMSSW_VERSION}/src/FastPUPPI/NtupleProducer/python/jetTuple_${TRACK_ALGO}_${N_PARAMS}.root
       - ${CMSSW_VERSION}/cmsRun.log
       - ${CMSSW_VERSION}/compilation.log

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -178,10 +178,10 @@ emulation-evaluate:
   script:
   - mkdir data
   - cd data
-  - cp ../${CMSSW_VERSION}/src/FastPUPPI/NtupleProducer/python/jetTuple_extended_5.root .
+  - cp ../${CMSSW_VERSION}/src/FastPUPPI/NtupleProducer/python/jetTuple_${TRACK_ALGO}_${N_PARAMS}.root .
   - cd ..
   - source activate tagger
-  - python tagger/plot/makeEmulationPlot.py -r True
+  - python tagger/plot/makeEmulationPlot.py -r True -i data/jetTuple_${TRACK_ALGO}_${N_PARAMS}.root
   artifacts:
     paths:
       - output/baseline
@@ -201,7 +201,7 @@ profile:
   - source activate tagger
   - mkdir data
   - cd data
-  - cp ../${CMSSW_VERSION}/src/FastPUPPI/NtupleProducer/python/jetTuple_extended_5.root .
+  - cp ../${CMSSW_VERSION}/src/FastPUPPI/NtupleProducer/python/jetTuple_${TRACK_ALGO}_${N_PARAMS}.root .
   - cd ..
   - pip uninstall hls4ml -y
   - git clone https://github.com/CMS-L1T-Jet-Tagging/hls4ml.git -b jet_tagger
@@ -209,7 +209,7 @@ profile:
   - pip install .[profiling]
   - cd ..
   - ls tagger/firmware/L1TSC4NGJetModel/L1TSC4NGJetModel_prj/solution1/syn/report/
-  - python tagger/firmware/hls4ml_profile.py -r True -n $Name
+  - python tagger/firmware/hls4ml_profile.py -r True -n $Name -i data/jetTuple_${TRACK_ALGO}_${N_PARAMS}.root
   artifacts:
     paths:
       - output/baseline

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -23,8 +23,8 @@ variables:
     EOS_STORAGE_SUBDIR: branches/${CI_COMMIT_REF_SLUG}/pipeline${CI_PIPELINE_ID}
     EOS_STORAGE_DATADIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/TrainingFiles
     SCRAM_ARCH: 'el9_amd64_gcc12'
-    CMSSW_VERSION: 'CMSSW_14_2_0_pre2'
-    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:14_2_pre2_L1TSC4NGJetTagger'
+    CMSSW_VERSION: 'CMSSW_15_1_0_pre1'
+    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:15_1_pre1_L1TSC4NGJetTagger'
 
 .template:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -50,7 +50,7 @@ make
 make install
 cd ..
 
-git clone https://github.com/CMS-L1T-Jet-Tagging/FastPUPPI.git -b 14_2_0/L1TSC4NGJetTagger
+git clone https://github.com/CMS-L1T-Jet-Tagging/FastPUPPI.git -b 15_1_0/L1TSC4NGJetTagger
 
 
 if [[ "$COMPILE" == "false" ]]; then exit 0; fi

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -66,7 +66,8 @@ if [[ "$RUN" == "false" ]]; then exit 0; fi
 
 cd FastPUPPI/NtupleProducer/python
 cmsenv
-
+sed -i -e 's/trktype = "extended"/trktype = "$TRACK_ALGO"/g' runJetNTuple.py
+sed -i -e 's/nparam = 5/nparam = $N_PARAMS/g' runJetNTuple.py
 echo "Temporary workaround to get the input files"
 #curl -s https://cerminar.web.cern.ch/cerminar/data/14_0_X/fpinputs_131X/v3/TTbar_PU200/inputs131X_1.root -o inputs131X_1.root
 #echo '\nprocess.source.fileNames = ["file:inputs131X_1.root"]' >> runJetNTuple.py

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -66,8 +66,8 @@ if [[ "$RUN" == "false" ]]; then exit 0; fi
 
 cd FastPUPPI/NtupleProducer/python
 cmsenv
-sed -i -e 's/trktype = "extended"/trktype = "$TRACK_ALGO"/g' runJetNTuple.py
-sed -i -e 's/nparam = 5/nparam = $N_PARAMS/g' runJetNTuple.py
+sed -i -e 's/trktype = "extended"/trktype = "${TRACK_ALGO}"/g' runJetNTuple.py
+sed -i -e 's/nparam = 5/nparam = ${N_PARAMS}/g' runJetNTuple.py
 echo "Temporary workaround to get the input files"
 #curl -s https://cerminar.web.cern.ch/cerminar/data/14_0_X/fpinputs_131X/v3/TTbar_PU200/inputs131X_1.root -o inputs131X_1.root
 #echo '\nprocess.source.fileNames = ["file:inputs131X_1.root"]' >> runJetNTuple.py

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -38,10 +38,8 @@ git config user.name "Chriisbrown"
 
 
 
-git clone --quiet https://github.com/CMS-L1T-Jet-Tagging/hls4ml-jettagger.git 
-mv hls4ml-jettagger L1TSC4NGJetModel
+git clone --quiet https://github.com/cms-hls4ml/L1TSC4NGJetModel.git
 cd L1TSC4NGJetModel
-git checkout L1TSC4NGJetModel
 
 cp -r ../../../tagger/firmware/L1TSC4NGJetModel/firmware L1TSC4NGJetModel/
 ./setup.sh

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -66,8 +66,10 @@ if [[ "$RUN" == "false" ]]; then exit 0; fi
 
 cd FastPUPPI/NtupleProducer/python
 cmsenv
-sed -i -e 's/trktype = "extended"/trktype = "${TRACK_ALGO}"/g' runJetNTuple.py
-sed -i -e 's/nparam = 5/nparam = ${N_PARAMS}/g' runJetNTuple.py
+echo ${TRACK_ALGO}
+echo  ${N_PARAMS}
+sed -i -e 's/trktype = "extended"/trktype = "'${TRACK_ALGO}'"/g' runJetNTuple.py
+sed -i -e 's/nparam = 5/nparam = '${N_PARAMS}'/g' runJetNTuple.py
 echo "Temporary workaround to get the input files"
 #curl -s https://cerminar.web.cern.ch/cerminar/data/14_0_X/fpinputs_131X/v3/TTbar_PU200/inputs131X_1.root -o inputs131X_1.root
 #echo '\nprocess.source.fileNames = ["file:inputs131X_1.root"]' >> runJetNTuple.py


### PR DESCRIPTION
Migrates the emulation to CMSSW 15_1 for both the CMSSW branch and fast PUPPI branch
Other changes include:

- Specifying baseline/extended and 4/5 tracking algorithm parameters when running emulator
- Specify correct jet nutple when running emulation comparison

Needed as previous 15_1 migration PR had broken git history