### PR TITLE
Emulator fix

### DIFF
--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -208,7 +208,6 @@ profile:
   - cd hls4ml
   - pip install .[profiling]
   - cd ..
-  - ls tagger/firmware/L1TSC4NGJetModel/L1TSC4NGJetModel_prj/solution1/syn/report/
   - python tagger/firmware/hls4ml_profile.py -r True -n $Name -i data/jetTuple_${TRACK_ALGO}_${N_PARAMS}.root
   artifacts:
     paths:

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -33,12 +33,8 @@ make install
 cd ..
 git clone --quiet https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git hls
 
-git config user.email chris.brown@fpsl.net
-git config user.name "Chriisbrown"
-
-
-
 git clone --quiet https://github.com/cms-hls4ml/L1TSC4NGJetModel.git
+git checkout -b emulator_test
 cd L1TSC4NGJetModel
 
 cp -r ../../../tagger/firmware/L1TSC4NGJetModel/firmware L1TSC4NGJetModel/
@@ -71,4 +67,6 @@ sed -i -e 's/nparam = 5/nparam = '${N_PARAMS}'/g' runJetNTuple.py
 echo "Temporary workaround to get the input files"
 #curl -s https://cerminar.web.cern.ch/cerminar/data/14_0_X/fpinputs_131X/v3/TTbar_PU200/inputs131X_1.root -o inputs131X_1.root
 #echo '\nprocess.source.fileNames = ["file:inputs131X_1.root"]' >> runJetNTuple.py
+
+echo process.l1tSC4NGJetProducer.l1tSC4NGJetModelPath = cms.string(os.environ['CMSSW_BASE']+"/src/L1TSC4NGJetModel/L1TSC4NGJetModel_test") >> runJetNTuple.py
 cmsRun runJetNTuple.py --tm18 2>&1 | tee cmsRun.log

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -34,8 +34,8 @@ cd ..
 git clone --quiet https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git hls
 
 git clone --quiet https://github.com/cms-hls4ml/L1TSC4NGJetModel.git
-git checkout -b emulator_test
 cd L1TSC4NGJetModel
+git checkout -b emulator_test
 
 cp -r ../../../tagger/firmware/L1TSC4NGJetModel/firmware L1TSC4NGJetModel/
 ./setup.sh
@@ -68,5 +68,5 @@ echo "Temporary workaround to get the input files"
 #curl -s https://cerminar.web.cern.ch/cerminar/data/14_0_X/fpinputs_131X/v3/TTbar_PU200/inputs131X_1.root -o inputs131X_1.root
 #echo '\nprocess.source.fileNames = ["file:inputs131X_1.root"]' >> runJetNTuple.py
 
-echo process.l1tSC4NGJetProducer.l1tSC4NGJetModelPath = cms.string(os.environ['CMSSW_BASE']+"/src/L1TSC4NGJetModel/L1TSC4NGJetModel_test") >> runJetNTuple.py
+echo 'process.l1tSC4NGJetProducer.l1tSC4NGJetModelPath = cms.string(os.environ['CMSSW_BASE']+"/src/L1TSC4NGJetModel/L1TSC4NGJetModel_test")' >> runJetNTuple.py
 cmsRun runJetNTuple.py --tm18 2>&1 | tee cmsRun.log

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -35,9 +35,10 @@ git clone --quiet https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git hl
 
 git clone --quiet https://github.com/cms-hls4ml/L1TSC4NGJetModel.git
 cd L1TSC4NGJetModel
-git checkout -b emulator_test
+git checkout emulator_test
 
-cp -r ../../../tagger/firmware/L1TSC4NGJetModel/firmware L1TSC4NGJetModel/
+cp -r ../../../tagger/firmware/L1TSC4NGJetModel/firmware .
+mv firmware L1TSC4NGJetModel
 ./setup.sh
 
 make 
@@ -68,5 +69,5 @@ echo "Temporary workaround to get the input files"
 #curl -s https://cerminar.web.cern.ch/cerminar/data/14_0_X/fpinputs_131X/v3/TTbar_PU200/inputs131X_1.root -o inputs131X_1.root
 #echo '\nprocess.source.fileNames = ["file:inputs131X_1.root"]' >> runJetNTuple.py
 
-echo 'process.l1tSC4NGJetProducer.l1tSC4NGJetModelPath = cms.string(os.environ['CMSSW_BASE']+"/src/L1TSC4NGJetModel/L1TSC4NGJetModel_test")' >> runJetNTuple.py
+echo 'process.l1tSC4NGJetProducer.l1tSC4NGJetModelPath = cms.string(os.environ["CMSSW_BASE"]+"/src/L1TSC4NGJetModel/L1TSC4NGJetModel_test")' >> runJetNTuple.py
 cmsRun runJetNTuple.py --tm18 2>&1 | tee cmsRun.log

--- a/tagger/firmware/hls4ml_convert.py
+++ b/tagger/firmware/hls4ml_convert.py
@@ -58,7 +58,7 @@ def convert(model, outpath,build=True):
     #Write HLS
     hls_model = hls4ml.converters.convert_from_keras_model(model,
                                                        backend='Vitis',
-                                                       project_name='L1TSC4NGJetModel',
+                                                       project_name='L1TSC4NGJetModel_test',
                                                        clock_period=2.8, #1/360MHz = 2.8ns
                                                        hls_config=config,
                                                        output_dir=f'{outpath}',

--- a/tagger/firmware/hls4ml_profile.py
+++ b/tagger/firmware/hls4ml_profile.py
@@ -115,6 +115,7 @@ if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument('-m','--model', default='output/baseline/model/saved_model.h5' , help = 'Input model path for comparison')    
     parser.add_argument('-o','--outpath', default='output/baseline/plots/profile' , help = 'Jet tagger plotting directory')    
+    parser.add_argument('-of','--outpath_firmware', default='output/baseline/model/firmware' , help = 'Jet tagger firmware directory') 
     parser.add_argument('-i','--input', default='data/jetTuple_extended_5.root' , help = 'Path to profiling data rootfile')
     parser.add_argument('-r','--remake', default=False , help = 'Remake profiling data? ')
     parser.add_argument('-n','--name',default='baseline', help= 'Mlfow model name? ')
@@ -137,7 +138,7 @@ if __name__ == "__main__":
                         run_name=args.name,
                         run_id=run_id # pass None to start a new run
                         ):
-        precisions = convert(model,args.outpath)
+        precisions = convert(model,args.outpath_firmware)
         report = getReports('tagger/firmware/L1TSC4NGJetModel')
         mlflow.log_metric('FF',report['ff_rel'])
         mlflow.log_metric('LUT',report['lut_rel'])

--- a/tagger/firmware/hls4ml_profile.py
+++ b/tagger/firmware/hls4ml_profile.py
@@ -26,7 +26,7 @@ style.set_style()
 def getReports(indir):
     data_ = {}
     
-    report_csynth = Path('{}/L1TSC4NGJetModel_prj/solution1/syn/report/L1TSC4NGJetModel_csynth.rpt'.format(indir))
+    report_csynth = Path('{}/L1TSC4NGJetModel_test_prj/solution1/syn/report/L1TSC4NGJetModel_test_csynth.rpt'.format(indir))
 
     if report_csynth.is_file():
         print('Found valid vsynth and synth in {}! Fetching numbers'.format(indir))


### PR DESCRIPTION
This PR ensures the emulator is correctly using the model generated in the CI and not the v0.0.0 tagged model, it now creates an hls4ml _test tag that is used in conjunction with a cms-hsl4ml emulator_test branch to run the model. The pipeline will now correctly fail if the model generated in the CI is not compatible with the emulation