### PR TITLE
Generic emulator update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ DeepSet:baseline_5param_extended_trk:
   variables:
     Name: baseline_5param_extended_trk
     Model: baseline
-    RERUN_ON_TAG: 'False'
+    RERUN_ON_TAG: 'True'
     RUN_EMULATION: 'True'
     RUN_SYNTHESIS: 'True'
 

--- a/CI/cmssw.yml
+++ b/CI/cmssw.yml
@@ -1,6 +1,6 @@
 emulate:
   tags: [ k8s-cvmfs ]
-  image: gitlab-registry.cern.ch/cms-cloud/cmssw-docker/al9-cms:latest
+  image: gitlab-registry.cern.ch/cms-cloud/cmssw-docker/al8-cms:latest
 
   stage: emulate
   needs: [hls4ml]

--- a/CI/cmssw.yml
+++ b/CI/cmssw.yml
@@ -1,6 +1,6 @@
 emulate:
   tags: [ k8s-cvmfs ]
-  image: gitlab-registry.cern.ch/ci-tools/ci-worker:cs8
+  image: gitlab-registry.cern.ch/linuxsupport/alma10-base
 
   stage: emulate
   needs: [hls4ml]

--- a/CI/cmssw.yml
+++ b/CI/cmssw.yml
@@ -1,5 +1,5 @@
 emulate:
-  tags: [ k8s-cvmfs ]
+  tags: [ cern-nextgen-highmem ]
   image: gitlab-registry.cern.ch/cms-cloud/cmssw-docker/al9-cms:latest
   stage: emulate
   needs: [hls4ml]

--- a/CI/cmssw.yml
+++ b/CI/cmssw.yml
@@ -7,7 +7,7 @@ emulate:
   rules:
     - if: ($RUN_EMULATION == "True") &&  ($RUN_SYNTHESIS == "True")
   before_script:
-    - yum install -q -y python3 python3-virtualenv mesa-libGL-devel mesa-libGLU-devel libXpm-devel openssl-devel ncurses-compat-libs
+    #- yum install -q -y python3 python3-virtualenv mesa-libGL-devel mesa-libGLU-devel libXpm-devel openssl-devel ncurses-compat-libs
     - source /cvmfs/grid.cern.ch/etc/profile.d/setup-cvmfs-ui.sh
     - source /cvmfs/cms.cern.ch/cmsset_default.sh
     - echo "$AUTO_DEVOPS_CERNBOX_PASS" | kinit "$AUTO_DEVOPS_CERNBOX_USER@CERN.CH" > /dev/null

--- a/CI/cmssw.yml
+++ b/CI/cmssw.yml
@@ -1,7 +1,6 @@
 emulate:
   tags: [ k8s-cvmfs ]
   image: gitlab-registry.cern.ch/cms-cloud/cmssw-docker/al8-cms:latest
-
   stage: emulate
   needs: [hls4ml]
   rules:

--- a/CI/cmssw.yml
+++ b/CI/cmssw.yml
@@ -1,6 +1,6 @@
 emulate:
   tags: [ k8s-cvmfs ]
-  image: gitlab-registry.cern.ch/linuxsupport/alma9-base
+  image: gitlab-registry.cern.ch/cms-cloud/cmssw-docker/al9-cms:latest
 
   stage: emulate
   needs: [hls4ml]

--- a/CI/cmssw.yml
+++ b/CI/cmssw.yml
@@ -1,12 +1,13 @@
 emulate:
-  tags: [ cern-nextgen-highmem ]
-  image: gitlab-registry.cern.ch/cms-cloud/cmssw-docker/al9-cms:latest
+  tags: [ k8s-cvmfs ]
+  image: gitlab-registry.cern.ch/ci-tools/ci-worker:cs8
+
   stage: emulate
   needs: [hls4ml]
   rules:
     - if: ($RUN_EMULATION == "True") &&  ($RUN_SYNTHESIS == "True")
   before_script:
-    #- yum install -q -y python3 python3-virtualenv mesa-libGL-devel mesa-libGLU-devel libXpm-devel openssl-devel ncurses-compat-libs
+    - yum install -q -y python3 python3-virtualenv mesa-libGL-devel mesa-libGLU-devel libXpm-devel openssl-devel ncurses-compat-libs
     - source /cvmfs/grid.cern.ch/etc/profile.d/setup-cvmfs-ui.sh
     - source /cvmfs/cms.cern.ch/cmsset_default.sh
     - echo "$AUTO_DEVOPS_CERNBOX_PASS" | kinit "$AUTO_DEVOPS_CERNBOX_USER@CERN.CH" > /dev/null

--- a/CI/cmssw.yml
+++ b/CI/cmssw.yml
@@ -1,6 +1,6 @@
 emulate:
   tags: [ k8s-cvmfs ]
-  image: gitlab-registry.cern.ch/linuxsupport/alma10-base
+  image: gitlab-registry.cern.ch/linuxsupport/alma9-base
 
   stage: emulate
   needs: [hls4ml]

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -33,8 +33,8 @@ variables:
     EOS_STORAGE_DIR: /eos/project/c/cms-l1t-jet-tagger/www/${CI_PROJECT_NAME}
     EOS_STORAGE_SUBDIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/pipeline${CI_PIPELINE_ID}
     EOS_STORAGE_DATADIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/TrainingFiles
-    CMSSW_VERSION: 'CMSSW_17_0_0_pre2'
-    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:CMSSW_17_0_0_pre2_NGJet'
+    CMSSW_VERSION: 'CMSSW_20_0_0_pre1'
+    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:CMSSW_20_0_0_pre1_NGJet'
     CMSSW_EMULATOR_WRAPPER: 'https://github.com/cms-hls4ml/L1TSC4NGJetModel.git'
     RERUN_ON_TAG: 'False'
     RUN_EMULATION: 'True'

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -59,9 +59,6 @@ data:
     - .template
   stage: data
   tags: [cern-nextgen-cpu]
-  variables:
-    KUBERNETES_MEMORY_REQUEST: 32Gi
-    KUBERNETES_CPU_REQUEST: 2
   rules:
     - changes:  # Include the job and set to when:manual if any of the follow paths match a modified file.
         - tagger/data/**
@@ -146,9 +143,6 @@ evaluate:
 
 hls4ml:
   tags: [cern-nextgen-gpu]
-  variables:
-    KUBERNETES_MEMORY_REQUEST: 32Gi
-    KUBERNETES_CPU_REQUEST: 4
   extends:
     - .template
   rules:
@@ -189,10 +183,7 @@ emulation-evaluate:
   extends:
     - .template
   stage: emulation-evaluate
-  tags: [cern-nextgen-cpu]
-  variables:
-    KUBERNETES_MEMORY_REQUEST: 8Gi
-    KUBERNETES_CPU_REQUEST: 2
+  tags: [cern-nextgen-]
   rules:
     - if: ($RUN_EMULATION == "True") && ($RUN_SYNTHESIS == "True")
   needs: [emulate,train,hls4ml]
@@ -213,10 +204,7 @@ profile:
   extends:
     - .template
   stage: profile
-  tags: [cern-nextgen-cpu]
-  variables:
-    KUBERNETES_MEMORY_REQUEST: 8Gi
-    KUBERNETES_CPU_REQUEST: 2
+  tags: [cern-nextgen-]
   needs: [emulate,synth,train]
   dependencies: [emulate,synth,train]
   rules:
@@ -238,9 +226,6 @@ upload_new_model:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest
   stage: upload
   tags: [cern-nextgen-cpu]
-  variables:
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_CPU_REQUEST: 1
   rules:
     - if: $RERUN_ON_TAG == "False"
   needs:
@@ -271,9 +256,6 @@ upload_tagged_model:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest
   stage: upload
   tags: [cern-nextgen-cpu]
-  variables:
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_CPU_REQUEST: 1
   needs: [emulation-evaluate,hls4ml,train,evaluate,profile,synth]
   dependencies: [emulation-evaluate,hls4ml,train,evaluate,profile,synth]
   rules:

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -102,7 +102,7 @@ evaluate:
   extends:
     - .template
   stage: evaluate
-  tags: [cern-nextgen-gpu]
+  tags: [cern-nextgen-w7900]
   script:
   - nproc
   - eos cp ${EOS_STORAGE_DIR}/${EOS_STORAGE_DATADIR}/training_data_$Inputs.tgz .

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -58,7 +58,7 @@ data:
   extends:
     - .template
   stage: data
-  tags: [cern-nextgen-cpu]
+  tags: [cern-nextgen-gpu]
   rules:
     - changes:  # Include the job and set to when:manual if any of the follow paths match a modified file.
         - tagger/data/**
@@ -183,7 +183,7 @@ emulation-evaluate:
   extends:
     - .template
   stage: emulation-evaluate
-  tags: [cern-nextgen-cpu]
+  tags: [cern-nextgen-gpu]
   rules:
     - if: ($RUN_EMULATION == "True") && ($RUN_SYNTHESIS == "True")
   needs: [emulate,train,hls4ml]
@@ -204,7 +204,7 @@ profile:
   extends:
     - .template
   stage: profile
-  tags: [cern-nextgen-cpu]
+  tags: [cern-nextgen-gpu]
   needs: [emulate,synth,train]
   dependencies: [emulate,synth,train]
   rules:
@@ -225,7 +225,7 @@ profile:
 upload_new_model:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest
   stage: upload
-  tags: [cern-nextgen-cpu]
+  tags: [k8s-default]
   rules:
     - if: $RERUN_ON_TAG == "False"
   needs:
@@ -255,7 +255,7 @@ upload_new_model:
 upload_tagged_model:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest
   stage: upload
-  tags: [cern-nextgen-cpu]
+  tags: [k8s-default]
   needs: [emulation-evaluate,hls4ml,train,evaluate,profile,synth]
   dependencies: [emulation-evaluate,hls4ml,train,evaluate,profile,synth]
   rules:

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -255,7 +255,7 @@ upload_new_model:
 upload_tagged_model:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest
   stage: upload
-  tags: [k8s-default]
+  tags: [k8s-gpu]
   needs: [emulation-evaluate,hls4ml,train,evaluate,profile,synth]
   dependencies: [emulation-evaluate,hls4ml,train,evaluate,profile,synth]
   rules:

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -34,7 +34,7 @@ variables:
     EOS_STORAGE_SUBDIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/pipeline${CI_PIPELINE_ID}
     EOS_STORAGE_DATADIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/TrainingFiles
     CMSSW_VERSION: 'CMSSW_17_0_0_pre2'
-    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:CMSSW_17_0_0_pre2_NGJet'
+    CMSSW_L1CT: 'CMSSW_17_0_0_pre2_NGJet_plus_correlator'
     CMSSW_EMULATOR_WRAPPER: 'https://github.com/cms-hls4ml/L1TSC4NGJetModel.git'
     RERUN_ON_TAG: 'False'
     RUN_EMULATION: 'True'

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -36,7 +36,7 @@ variables:
     CMSSW_VERSION: 'CMSSW_15_1_0_pre4'
     CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:L1PF_15_1_X_GenericEmulator'
     CMSSW_EMULATOR_WRAPPER: 'https://github.com/cms-hls4ml/L1TSC4NGJetModel.git'
-    RERUN_ON_TAG: 'True'
+    RERUN_ON_TAG: 'False'
     RUN_EMULATION: 'True'
     RUN_SYNTHESIS: 'True'
     TAG: 'v1.0.1'

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -183,7 +183,7 @@ emulation-evaluate:
   extends:
     - .template
   stage: emulation-evaluate
-  tags: [cern-nextgen-]
+  tags: [cern-nextgen-cpu]
   rules:
     - if: ($RUN_EMULATION == "True") && ($RUN_SYNTHESIS == "True")
   needs: [emulate,train,hls4ml]
@@ -204,7 +204,7 @@ profile:
   extends:
     - .template
   stage: profile
-  tags: [cern-nextgen-]
+  tags: [cern-nextgen-cpu]
   needs: [emulate,synth,train]
   dependencies: [emulate,synth,train]
   rules:

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -169,7 +169,7 @@ hls4ml:
 
 synth:
   tags:
-    - fpga-mid
+    - fpga-large
   image: registry.cern.ch/ci4fpga/vivado:2023.2
   stage: synth
   needs : [hls4ml]

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -265,6 +265,8 @@ upload_tagged_model:
     - echo "$AUTO_DEVOPS_CERNBOX_PASS" | kinit "$AUTO_DEVOPS_CERNBOX_USER@CERN.CH" > /dev/null
   script:
     - source activate tagger
+    - echo ${EOS_STORAGE_DIR}/tags/${TAG}
+    - ls ${EOS_STORAGE_DIR}/tags/${TAG}/
     - mkdir -p ${EOS_STORAGE_DIR}/tags/${TAG}/test/firmware
     - mkdir -p ${EOS_STORAGE_DIR}/tags/${TAG}/test/plots
     - mkdir $Name

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -158,6 +158,11 @@ hls4ml:
     - job : train
       optional: true
   script:
+  - pip uninstall hls4ml -y
+  - git clone https://github.com/CMS-L1T-Jet-Tagging/hls4ml.git -b jet_tagger_hls4ml_update
+  - cd hls4ml
+  - pip install .[profiling]
+  - cd ..
   - eos cp ${EOS_STORAGE_DIR}/${EOS_STORAGE_DATADIR}/training_data_$Inputs.tgz .
   - tar -xf training_data_$Inputs.tgz
   - source activate tagger
@@ -198,6 +203,11 @@ emulation-evaluate:
   needs: [emulate,train,hls4ml]
   dependencies: [emulate,train,hls4ml]
   script:
+  - pip uninstall hls4ml -y
+  - git clone https://github.com/CMS-L1T-Jet-Tagging/hls4ml.git -b jet_tagger_hls4ml_update
+  - cd hls4ml
+  - pip install .[profiling]
+  - cd ..
   - mkdir data
   - cd data
   - cp ../${CMSSW_VERSION}/src/FastPUPPI/NtupleProducer/python/jetTuple_${TRACK_ALGO}_${N_PARAMS}.root .
@@ -228,7 +238,7 @@ profile:
   - cp ../${CMSSW_VERSION}/src/FastPUPPI/NtupleProducer/python/jetTuple_${TRACK_ALGO}_${N_PARAMS}.root .
   - cd ..
   - pip uninstall hls4ml -y
-  - git clone https://github.com/CMS-L1T-Jet-Tagging/hls4ml.git -b jet_tagger
+  - git clone https://github.com/CMS-L1T-Jet-Tagging/hls4ml.git -b jet_tagger_hls4ml_update
   - cd hls4ml
   - pip install .[profiling]
   - cd ..

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -36,10 +36,10 @@ variables:
     CMSSW_VERSION: 'CMSSW_15_1_0_pre4'
     CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:L1PF_15_1_X_GenericEmulator'
     CMSSW_EMULATOR_WRAPPER: 'https://github.com/cms-hls4ml/L1TSC4NGJetModel.git'
-    RERUN_ON_TAG: 'False'
+    RERUN_ON_TAG: 'True'
     RUN_EMULATION: 'True'
     RUN_SYNTHESIS: 'True'
-    TAG: 'v0.0.0'
+    TAG: 'v1.0.1'
 
 .template:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -33,8 +33,8 @@ variables:
     EOS_STORAGE_DIR: /eos/project/c/cms-l1t-jet-tagger/www/${CI_PROJECT_NAME}
     EOS_STORAGE_SUBDIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/pipeline${CI_PIPELINE_ID}
     EOS_STORAGE_DATADIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/TrainingFiles
-    CMSSW_VERSION: 'CMSSW_15_1_0_pre4'
-    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:L1PF_15_1_X_GenericEmulator'
+    CMSSW_VERSION: 'CMSSW_17_0_0_pre2'
+    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:CMSSW_17_0_0_pre2_NGJet'
     CMSSW_EMULATOR_WRAPPER: 'https://github.com/cms-hls4ml/L1TSC4NGJetModel.git'
     RERUN_ON_TAG: 'False'
     RUN_EMULATION: 'True'
@@ -274,8 +274,8 @@ upload_tagged_model:
   variables:
     KUBERNETES_MEMORY_REQUEST: 4Gi
     KUBERNETES_CPU_REQUEST: 1
-  needs: [emulation-evaluate,hls4ml,train,evaluate,profile]
-  dependencies: [emulation-evaluate,hls4ml,train,evaluate,profile]
+  needs: [emulation-evaluate,hls4ml,train,evaluate,profile,synth]
+  dependencies: [emulation-evaluate,hls4ml,train,evaluate,profile,synth]
   rules:
     - if: $RERUN_ON_TAG == "True"
   before_script:
@@ -286,10 +286,10 @@ upload_tagged_model:
     - mkdir -p ${EOS_STORAGE_DIR}/tags/${TAG}/test/firmware
     - mkdir -p ${EOS_STORAGE_DIR}/tags/${TAG}/test/plots
     - mkdir $Name
-    - cd tagger/firmware
+    - cd output/$Model/firmware
     - tar -cvf L1TSC4NGJetModel.tgz L1TSC4NGJetModel
     - cp -r L1TSC4NGJetModel.tgz ${EOS_STORAGE_DIR}/tags/${TAG}/test/firmware/
-    - cd ../..
+    - cd ../../..
     - mkdir $Name/plots
     - mv output/$Model/plots/emulation $Name/plots
     - mv output/$Model/plots/profile $Name/plots

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -58,7 +58,7 @@ data:
   extends:
     - .template
   stage: data
-  tags: [cern-nextgen-highmem]
+  tags: [cern-nextgen-cpu]
   variables:
     KUBERNETES_MEMORY_REQUEST: 32Gi
     KUBERNETES_CPU_REQUEST: 2
@@ -189,7 +189,7 @@ emulation-evaluate:
   extends:
     - .template
   stage: emulation-evaluate
-  tags: [cern-nextgen-highmem]
+  tags: [cern-nextgen-cpu]
   variables:
     KUBERNETES_MEMORY_REQUEST: 8Gi
     KUBERNETES_CPU_REQUEST: 2
@@ -213,7 +213,7 @@ profile:
   extends:
     - .template
   stage: profile
-  tags: [cern-nextgen-highmem]
+  tags: [cern-nextgen-cpu]
   variables:
     KUBERNETES_MEMORY_REQUEST: 8Gi
     KUBERNETES_CPU_REQUEST: 2
@@ -237,7 +237,7 @@ profile:
 upload_new_model:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest
   stage: upload
-  tags: [cern-nextgen-highmem]
+  tags: [cern-nextgen-cpu]
   variables:
     KUBERNETES_MEMORY_REQUEST: 4Gi
     KUBERNETES_CPU_REQUEST: 1
@@ -270,7 +270,7 @@ upload_new_model:
 upload_tagged_model:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest
   stage: upload
-  tags: [cern-nextgen-highmem]
+  tags: [cern-nextgen-cpu]
   variables:
     KUBERNETES_MEMORY_REQUEST: 4Gi
     KUBERNETES_CPU_REQUEST: 1

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -33,8 +33,8 @@ variables:
     EOS_STORAGE_DIR: /eos/project/c/cms-l1t-jet-tagger/www/${CI_PROJECT_NAME}
     EOS_STORAGE_SUBDIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/pipeline${CI_PIPELINE_ID}
     EOS_STORAGE_DATADIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/TrainingFiles
-    CMSSW_VERSION: 'CMSSW_20_0_0_pre1'
-    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:CMSSW_20_0_0_pre1_NGJet'
+    CMSSW_VERSION: 'CMSSW_17_0_0_pre2'
+    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:CMSSW_17_0_0_pre2_NGJet'
     CMSSW_EMULATOR_WRAPPER: 'https://github.com/cms-hls4ml/L1TSC4NGJetModel.git'
     RERUN_ON_TAG: 'False'
     RUN_EMULATION: 'True'

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -58,7 +58,7 @@ data:
   extends:
     - .template
   stage: data
-  tags: [cern-nextgen-cpuintensive]
+  tags: [cern-nextgen-highmem]
   variables:
     KUBERNETES_MEMORY_REQUEST: 32Gi
     KUBERNETES_CPU_REQUEST: 2
@@ -189,7 +189,7 @@ emulation-evaluate:
   extends:
     - .template
   stage: emulation-evaluate
-  tags: [cern-nextgen-cpuintensive]
+  tags: [cern-nextgen-highmem]
   variables:
     KUBERNETES_MEMORY_REQUEST: 8Gi
     KUBERNETES_CPU_REQUEST: 2
@@ -213,7 +213,7 @@ profile:
   extends:
     - .template
   stage: profile
-  tags: [cern-nextgen-cpuintensive]
+  tags: [cern-nextgen-highmem]
   variables:
     KUBERNETES_MEMORY_REQUEST: 8Gi
     KUBERNETES_CPU_REQUEST: 2
@@ -237,7 +237,7 @@ profile:
 upload_new_model:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest
   stage: upload
-  tags: [cern-nextgen-cpuintensive]
+  tags: [cern-nextgen-highmem]
   variables:
     KUBERNETES_MEMORY_REQUEST: 4Gi
     KUBERNETES_CPU_REQUEST: 1
@@ -270,7 +270,7 @@ upload_new_model:
 upload_tagged_model:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest
   stage: upload
-  tags: [cern-nextgen-cpuintensive]
+  tags: [cern-nextgen-highmem]
   variables:
     KUBERNETES_MEMORY_REQUEST: 4Gi
     KUBERNETES_CPU_REQUEST: 1

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -223,6 +223,7 @@ profile:
     - if: ($RUN_EMULATION == "True") &&  ($RUN_SYNTHESIS == "True")
   script:
   - source activate tagger
+  - pip install hls4ml[profiling]
   - mkdir data
   - cd data
   - cp ../${CMSSW_VERSION}/src/FastPUPPI/NtupleProducer/python/jetTuple_${TRACK_ALGO}_${N_PARAMS}.root .

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -49,7 +49,7 @@ variables:
     - env
   script:
     - python $FOLDER/$SCRIPT $ARGS
-  tags: [cern-nextgen-h100]
+  tags: [cern-nextgen-gpu]
   # rules: # run automatically on default branch, tags, and on merge requests with 'ci::automatic-build' label; otherwise run manually
   #    - if: '($CI_COMMIT_TAG || $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH || $CI_MERGE_REQUEST_LABELS =~ /ci::automatic-build/)'
   #      when: on_success
@@ -58,7 +58,7 @@ data:
   extends:
     - .template
   stage: data
-  tags: [k8s-gpu]
+  tags: [cern-nextgen-cpuintensive]
   variables:
     KUBERNETES_MEMORY_REQUEST: 32Gi
     KUBERNETES_CPU_REQUEST: 2
@@ -105,7 +105,7 @@ evaluate:
   extends:
     - .template
   stage: evaluate
-  tags: [cern-nextgen-h100]
+  tags: [cern-nextgen-gpu]
   script:
   - nproc
   - eos cp ${EOS_STORAGE_DIR}/${EOS_STORAGE_DATADIR}/training_data_$Inputs.tgz .
@@ -145,7 +145,7 @@ evaluate:
     expire_in: 7 days
 
 hls4ml:
-  tags: [cern-nextgen-h100]
+  tags: [cern-nextgen-gpu]
   variables:
     KUBERNETES_MEMORY_REQUEST: 32Gi
     KUBERNETES_CPU_REQUEST: 4
@@ -169,7 +169,7 @@ hls4ml:
 
 synth:
   tags:
-    - fpga-large
+    - fpga-mid
   image: registry.cern.ch/ci4fpga/vivado:2023.2
   stage: synth
   needs : [hls4ml]
@@ -189,7 +189,7 @@ emulation-evaluate:
   extends:
     - .template
   stage: emulation-evaluate
-  tags: [k8s-gpu]
+  tags: [cern-nextgen-cpuintensive]
   variables:
     KUBERNETES_MEMORY_REQUEST: 8Gi
     KUBERNETES_CPU_REQUEST: 2
@@ -213,7 +213,7 @@ profile:
   extends:
     - .template
   stage: profile
-  tags: [k8s-gpu]
+  tags: [cern-nextgen-cpuintensive]
   variables:
     KUBERNETES_MEMORY_REQUEST: 8Gi
     KUBERNETES_CPU_REQUEST: 2
@@ -237,7 +237,7 @@ profile:
 upload_new_model:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest
   stage: upload
-  tags: [k8s-gpu]
+  tags: [cern-nextgen-cpuintensive]
   variables:
     KUBERNETES_MEMORY_REQUEST: 4Gi
     KUBERNETES_CPU_REQUEST: 1
@@ -270,7 +270,7 @@ upload_new_model:
 upload_tagged_model:
   image: gitlab-registry.cern.ch/ml_l1/ops/docker-images/mamba_jettagger:latest
   stage: upload
-  tags: [k8s-gpu]
+  tags: [cern-nextgen-cpuintensive]
   variables:
     KUBERNETES_MEMORY_REQUEST: 4Gi
     KUBERNETES_CPU_REQUEST: 1

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -261,12 +261,14 @@ upload_tagged_model:
   rules:
     - if: $RERUN_ON_TAG == "True"
   before_script:
+    - export EOS_MGM_URL=root://eosproject.cern.ch
     - export PYTHONPATH=/builds/ml_l1/TrainTagger:$PYTHONPATH
     - echo "$AUTO_DEVOPS_CERNBOX_PASS" | kinit "$AUTO_DEVOPS_CERNBOX_USER@CERN.CH" > /dev/null
   script:
     - source activate tagger
     - echo ${EOS_STORAGE_DIR}/tags/${TAG}
-    - ls ${EOS_STORAGE_DIR}/tags/${TAG}/
+    - eos ls ${EOS_STORAGE_DIR}/tags/${TAG}
+    - ls ${EOS_STORAGE_DIR}/tags/${TAG}
     - mkdir -p ${EOS_STORAGE_DIR}/tags/${TAG}/test/firmware
     - mkdir -p ${EOS_STORAGE_DIR}/tags/${TAG}/test/plots
     - mkdir $Name

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -34,7 +34,7 @@ variables:
     EOS_STORAGE_SUBDIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/pipeline${CI_PIPELINE_ID}
     EOS_STORAGE_DATADIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/TrainingFiles
     CMSSW_VERSION: 'CMSSW_17_0_0_pre2'
-    CMSSW_L1CT: 'CMSSW_17_0_0_pre2_NGJet_plus_correlator'
+    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:CMSSW_17_0_0_pre2_NGJet_plus_correlator'
     CMSSW_EMULATOR_WRAPPER: 'https://github.com/cms-hls4ml/L1TSC4NGJetModel.git'
     RERUN_ON_TAG: 'False'
     RUN_EMULATION: 'True'

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -34,7 +34,7 @@ variables:
     EOS_STORAGE_SUBDIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/pipeline${CI_PIPELINE_ID}
     EOS_STORAGE_DATADIR: branches/${CI_COMMIT_REF_SLUG}/${Name}/TrainingFiles
     CMSSW_VERSION: 'CMSSW_15_1_0_pre4'
-    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:L1PF_15_1_X_L1TSC4NGJetTagger'
+    CMSSW_L1CT: 'CMS-L1T-Jet-Tagging:L1PF_15_1_X_GenericEmulator'
     CMSSW_EMULATOR_WRAPPER: 'https://github.com/cms-hls4ml/L1TSC4NGJetModel.git'
     RERUN_ON_TAG: 'False'
     RUN_EMULATION: 'True'

--- a/CI/ml_pipeline.yml
+++ b/CI/ml_pipeline.yml
@@ -158,11 +158,6 @@ hls4ml:
     - job : train
       optional: true
   script:
-  - pip uninstall hls4ml -y
-  - git clone https://github.com/CMS-L1T-Jet-Tagging/hls4ml.git -b jet_tagger_hls4ml_update
-  - cd hls4ml
-  - pip install .[profiling]
-  - cd ..
   - eos cp ${EOS_STORAGE_DIR}/${EOS_STORAGE_DATADIR}/training_data_$Inputs.tgz .
   - tar -xf training_data_$Inputs.tgz
   - source activate tagger
@@ -203,11 +198,6 @@ emulation-evaluate:
   needs: [emulate,train,hls4ml]
   dependencies: [emulate,train,hls4ml]
   script:
-  - pip uninstall hls4ml -y
-  - git clone https://github.com/CMS-L1T-Jet-Tagging/hls4ml.git -b jet_tagger_hls4ml_update
-  - cd hls4ml
-  - pip install .[profiling]
-  - cd ..
   - mkdir data
   - cd data
   - cp ../${CMSSW_VERSION}/src/FastPUPPI/NtupleProducer/python/jetTuple_${TRACK_ALGO}_${N_PARAMS}.root .
@@ -236,11 +226,6 @@ profile:
   - mkdir data
   - cd data
   - cp ../${CMSSW_VERSION}/src/FastPUPPI/NtupleProducer/python/jetTuple_${TRACK_ALGO}_${N_PARAMS}.root .
-  - cd ..
-  - pip uninstall hls4ml -y
-  - git clone https://github.com/CMS-L1T-Jet-Tagging/hls4ml.git -b jet_tagger_hls4ml_update
-  - cd hls4ml
-  - pip install .[profiling]
   - cd ..
   - python tagger/firmware/hls4ml_profile.py -r True -i data/jetTuple_${TRACK_ALGO}_${N_PARAMS}.root -m output/$Model -of output/$Model/firmware -o output/$Model/plots/profile
   artifacts:

--- a/CI/run_training.sh
+++ b/CI/run_training.sh
@@ -11,12 +11,15 @@ if [[ "$1" == "False" ]]; then
     eos cp saved_model.keras ${EOS_STORAGE_DIR}/${EOS_STORAGE_SUBDIR}/model/
     export MODEL_LOCATION=${EOS_STORAGE_DIR}/${EOS_STORAGE_SUBDIR}
 else
+    export MODEL_LOCATION=${EOS_STORAGE_DIR}/tags/${TAG}/
     mkdir -p output/$Model/model
     eos cp ${MODEL_LOCATION}/model/saved_model.* output/$Model/model
+    eos cp ${MODEL_LOCATION}/model/*.yaml output/$Model/
     eos cp ${MODEL_LOCATION}/extras/* output/$Model/
     mkdir -p output/$Model/testing_data
     eos cp ${MODEL_LOCATION}/testing_data/* output/$Model/testing_data
     eos cp ${MODEL_LOCATION}/signal_process_data.tgz .
     tar -xf signal_process_data.tgz
+    mkdir -p output/$Model/plots/training
     python tagger/train/train.py --plot-basic -sig $SIGNAL -y tagger/model/configs/$Model.yaml -o output/$Model
 fi

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -46,7 +46,7 @@ cd L1TSC4NGJetModel
 git checkout model_wrapper_v2
 
 cp -r ../../../output/$Model/firmware/L1TSC4NGJetModel/firmware .
-./setup.sh v2_0_0 v2_0_0
+./setup.sh test v2_0_0
 
 make
 make install
@@ -73,6 +73,6 @@ sed -i -e 's/trktype = "extended"/trktype = "'${TRACK_ALGO}'"/g' runJetNtuple.py
 sed -i -e 's/nparam = 5/nparam = '${N_PARAMS}'/g' runJetNtuple.py
 echo "Temporary workaround to get the input files"
 echo $'\nprocess.source.fileNames = ["file:/eos/cms/store/cmst3/group/l1tr/FastPUPPI/15_1_X/fpinputs_151X/v1/TT_PU200/inputs151X_10.root"]' >> runJetNtuple.py
-echo $'\nprocess.l1tSC4NGJetProducer.l1tSC4NGJetModelPath = cms.string(os.environ["CMSSW_BASE"]+"/src/L1TSC4NGJetModel/L1TSC4NGJetModel_v2_0_0")' >> runJetNtuple.py
+echo $'\nprocess.l1tSC4NGJetProducer.l1tSC4NGJetModelPath = cms.string(os.environ["CMSSW_BASE"]+"/src/L1TSC4NGJetModel/L1TSC4NGJetModel_test/L1TSC4NGJetModel_test")' >> runJetNtuple.py
 cat runJetNtuple.py
 cmsRun runJetNtuple.py --tm18 2>&1 | tee cmsRun.log

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -37,10 +37,10 @@ git clone --quiet https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git hl
 
 git clone --quiet ${CMSSW_EMULATOR_WRAPPER}
 cd L1TSC4NGJetModel
-git checkout model_wrapper_v2
+git checkout rework_v2_release
 
 cp -r ../../../output/$Model/firmware/L1TSC4NGJetModel/firmware .
-./setup.sh test v2_0_0
+./setup.sh test v1_0_1
 
 make
 make install

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SCRAM_ARCH=el9_amd64_gcc14
+export SCRAM_ARCH=el8_amd64_gcc13
 
 if [[ "$2" == "" ]]; then
     echo "Usage $0 [ -checkout | -compile | -run ] CMSSW_VERSION GITHUB_MASTER GITHUB_TAG [ GITHUB_PR ]"

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -33,13 +33,13 @@ mv L1Trigger-Phase2L1ParticleFlow data
 mv hadcorr_HGCal3D_TC.root data
 cd ../..
 
-git clone --quiet https://github.com/cms-hls4ml/hls4mlEmulatorExtras.git && \
-  cd hls4mlEmulatorExtras &&
-  git checkout -b v1.1.3 tags/v1.1.3
-make
-make install
-cd ..
-git clone --quiet https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git hls
+# git clone --quiet https://github.com/cms-hls4ml/hls4mlEmulatorExtras.git && \
+#   cd hls4mlEmulatorExtras &&
+#   git checkout -b v1.1.3 tags/v1.1.3
+# make
+# make install
+# cd ..
+# git clone --quiet https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git hls
 
 git clone --quiet ${CMSSW_EMULATOR_WRAPPER}
 cd L1TSC4NGJetModel

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -27,13 +27,13 @@ git remote add l1ct https://github.com/${CMSSW_L1CT%%:*}/cmssw.git -t ${CMSSW_L1
 git cms-addpkg L1Trigger/Phase2L1ParticleFlow
 git cms-addpkg L1Trigger/Configuration
 
-cd L1Trigger/Phase2L1ParticleFlow
-mv data/hadcorr_HGCal3D_TC.root .
-rm -r data
-git clone https://github.com/cms-data/L1Trigger-Phase2L1ParticleFlow.git
-mv L1Trigger-Phase2L1ParticleFlow data
-mv hadcorr_HGCal3D_TC.root data
-cd ../..
+#cd L1Trigger/Phase2L1ParticleFlow
+# mv data/hadcorr_HGCal3D_TC.root .
+# rm -r data
+# git clone https://github.com/cms-data/L1Trigger-Phase2L1ParticleFlow.git
+# mv L1Trigger-Phase2L1ParticleFlow data
+# mv hadcorr_HGCal3D_TC.root data
+# cd ../..
 
 # git clone --quiet https://github.com/cms-hls4ml/hls4mlEmulatorExtras.git && \
 #   cd hls4mlEmulatorExtras &&
@@ -54,7 +54,7 @@ make
 make install
 cd ..
 
-git clone https://github.com/CMS-L1T-Jet-Tagging/FastPUPPI.git -b 15_1_X_NGJet_EmulatorUpdate
+git clone https://github.com/CMS-L1T-Jet-Tagging/FastPUPPI.git -b 20_0_X_NGJet
 
 
 if [[ "$COMPILE" == "false" ]]; then exit 0; fi

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -46,7 +46,7 @@ make
 make install
 cd ..
 
-git clone https://github.com/CMS-L1T-Jet-Tagging/FastPUPPI.git -b 20_0_X_NGJet
+git clone https://github.com/CMS-L1T-Jet-Tagging/FastPUPPI.git -b CMSSW_17_0_0_pre2_NGJet_plus_correlator
 
 
 if [[ "$COMPILE" == "false" ]]; then exit 0; fi

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -27,21 +27,13 @@ git remote add l1ct https://github.com/${CMSSW_L1CT%%:*}/cmssw.git -t ${CMSSW_L1
 git cms-addpkg L1Trigger/Phase2L1ParticleFlow
 git cms-addpkg L1Trigger/Configuration
 
-#cd L1Trigger/Phase2L1ParticleFlow
-# mv data/hadcorr_HGCal3D_TC.root .
-# rm -r data
-# git clone https://github.com/cms-data/L1Trigger-Phase2L1ParticleFlow.git
-# mv L1Trigger-Phase2L1ParticleFlow data
-# mv hadcorr_HGCal3D_TC.root data
-# cd ../..
-
-# git clone --quiet https://github.com/cms-hls4ml/hls4mlEmulatorExtras.git && \
-#   cd hls4mlEmulatorExtras &&
-#   git checkout -b v1.1.3 tags/v1.1.3
-# make
-# make install
-# cd ..
-# git clone --quiet https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git hls
+git clone --quiet https://github.com/cms-hls4ml/hls4mlEmulatorExtras.git && \
+  cd hls4mlEmulatorExtras &&
+  git checkout -b v1.1.4 tags/v1.1.4
+make
+make install
+cd ..
+git clone --quiet https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git hls
 
 git clone --quiet ${CMSSW_EMULATOR_WRAPPER}
 cd L1TSC4NGJetModel

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export SCRAM_ARCH=el9_amd64_gcc14
+
 if [[ "$2" == "" ]]; then
     echo "Usage $0 [ -checkout | -compile | -run ] CMSSW_VERSION GITHUB_MASTER GITHUB_TAG [ GITHUB_PR ]"
     exit 1;

--- a/CI/setup_cmssw.sh
+++ b/CI/setup_cmssw.sh
@@ -43,16 +43,16 @@ git clone --quiet https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git hl
 
 git clone --quiet ${CMSSW_EMULATOR_WRAPPER}
 cd L1TSC4NGJetModel
-git checkout emulator_test
+git checkout model_wrapper_v2
 
 cp -r ../../../output/$Model/firmware/L1TSC4NGJetModel/firmware .
-./setup.sh v1
+./setup.sh v2_0_0 v2_0_0
 
 make
 make install
 cd ..
 
-git clone https://github.com/CMS-L1T-Jet-Tagging/FastPUPPI.git -b 15_1_X_NGJet
+git clone https://github.com/CMS-L1T-Jet-Tagging/FastPUPPI.git -b 15_1_X_NGJet_EmulatorUpdate
 
 
 if [[ "$COMPILE" == "false" ]]; then exit 0; fi
@@ -73,6 +73,6 @@ sed -i -e 's/trktype = "extended"/trktype = "'${TRACK_ALGO}'"/g' runJetNtuple.py
 sed -i -e 's/nparam = 5/nparam = '${N_PARAMS}'/g' runJetNtuple.py
 echo "Temporary workaround to get the input files"
 echo $'\nprocess.source.fileNames = ["file:/eos/cms/store/cmst3/group/l1tr/FastPUPPI/15_1_X/fpinputs_151X/v1/TT_PU200/inputs151X_10.root"]' >> runJetNtuple.py
-echo $'\nprocess.l1tSC4NGJetProducer.l1tSC4NGJetModelPath = cms.string(os.environ["CMSSW_BASE"]+"/src/L1TSC4NGJetModel/L1TSC4NGJetModel_v1")' >> runJetNtuple.py
+echo $'\nprocess.l1tSC4NGJetProducer.l1tSC4NGJetModelPath = cms.string(os.environ["CMSSW_BASE"]+"/src/L1TSC4NGJetModel/L1TSC4NGJetModel_v2_0_0")' >> runJetNtuple.py
 cat runJetNtuple.py
 cmsRun runJetNtuple.py --tm18 2>&1 | tee cmsRun.log

--- a/CI/upload_new_model.sh
+++ b/CI/upload_new_model.sh
@@ -13,6 +13,8 @@ if [ -z "${Name}" ] || [ -z "${Model}" ] || [ -z "${EOS_STORAGE_DIR}" ] || [ -z 
 fi
 mkdir $Name
 mkdir $Name/plots
+mv output/$Model/*.json $Name
+mv output/$Model/*.yaml $Name
 mv output/$Model/model $Name/model
 mv output/$Model/plots/training/ $Name/plots
 mv output/$Model/plots/physics/ $Name/plots

--- a/setup.sh
+++ b/setup.sh
@@ -18,3 +18,5 @@ export VBFHTAUTAU=VBFHToTauTau_PU200.root
 export NTUPLE_TREE=outnano/Jets
 export SIGNAL=TT_PU200
 export EOS_DATA_DIR='/eos/cms/store/cmst3/group/l1tr/sewuchte/l1teg/fp_jettuples_090125/'
+export CI_PROJECT_NAME='TrainTagger'
+export EOS_STORAGE_DIR='/eos/project/c/cms-l1t-jet-tagger/www/${CI_PROJECT_NAME}'

--- a/tagger/data/tools.py
+++ b/tagger/data/tools.py
@@ -375,7 +375,6 @@ def load_data(outdir, percentage, test_ratio=0.1, fields=None):
 
     return train_data, test_data, class_labels, input_vars, extra_vars
 
-
 def make_data(
     infile='/eos/cms/store/cmst3/group/l1tr/sewuchte/l1teg/fp_ntuples_v131Xv9/baselineTRK_4param_221124/All200.root',
     outdir='training_data/',

--- a/tagger/data/tools.py
+++ b/tagger/data/tools.py
@@ -347,7 +347,7 @@ def load_data(outdir, percentage, test_ratio=0.1, fields=None):
     chunks_to_load = int(np.ceil((percentage / 100) * total_chunks))
 
     # Collect the file paths for the chunks to load
-    chunk_files = [metadata[i]["file"] for i in range(chunks_to_load)]
+    chunk_files = [f"{metadata[i]['file']}:data" for i in range(chunks_to_load)]
 
     # Use uproot.concatenate to load and combine data from multiple files
     data = uproot.concatenate(chunk_files, filter_name=fields, library="ak")

--- a/tagger/firmware/hls4ml_profile.py
+++ b/tagger/firmware/hls4ml_profile.py
@@ -13,6 +13,8 @@ from tagger.model.common import fromFolder
 from tagger.plot import style
 from tagger.plot.common import plot_2d
 
+from hls4ml.model import profiling
+
 style.set_style()
 
 
@@ -90,14 +92,15 @@ def doPlots(model, outputdir, inputdir):
     figure.savefig("%s/%s_score_2D.pdf" % (outputdir, "Regression"), bbox_inches='tight')
     plt.close()
 
-    wp, wph, ap, aph = hls4ml.model.profiling.numerical(model=model.jet_model, hls_model=model.hls_jet_model, X=X_test)
+    print(hls4ml.__version__)
+    wp, wph, ap, aph = profiling.numerical(model=model.jet_model, hls_model=model.hls_jet_model, X=X_test)
     ap.savefig(outputdir + "/model_activations_profile.png")
     wp.savefig(outputdir + "/model_weights_profile.png")
     aph.savefig(outputdir + "/model_activations_profile_opt.png")
     wph.savefig(outputdir + "/model_weights_profile_opt.png")
 
     y_hls, hls4ml_trace = model.hls_jet_model.trace(np.ascontiguousarray(X_test))
-    keras_trace = hls4ml.model.profiling.get_ymodel_keras(model.jet_model, X_test)
+    keras_trace = profiling.get_ymodel_keras(model.jet_model, X_test)
 
     for layer in hls4ml_trace.keys():
         print("Doing profiling 2d for layer", layer)

--- a/tagger/model/DeepSetModel.py
+++ b/tagger/model/DeepSetModel.py
@@ -189,8 +189,10 @@ class DeepSetModel(QKerasModel):
             else:
                 config["LayerName"][layer.name]["Trace"] = not build
 
+        config["LayerName"]["Dense_3_jetID"]["Precision"]["result"] = self.firmware_config['input_precision']
         config["LayerName"]["jet_id_output"]["Precision"]["result"] = self.firmware_config['class_precision']
-        config["LayerName"]["jet_id_output"]["Implementation"] = "latency"
+        config["LayerName"]["jet_id_output"]["Implementation"] = "stable"
+        config['LayerName"]["jet_id_output"]["TableSize"] = 2048
         config["LayerName"]["pT_output"]["Precision"]["result"] = self.firmware_config['reg_precision']
         config["LayerName"]["pT_output"]["Implementation"] = "latency"
 

--- a/tagger/model/DeepSetModel.py
+++ b/tagger/model/DeepSetModel.py
@@ -190,7 +190,7 @@ class DeepSetModel(QKerasModel):
                 config["LayerName"][layer.name]["Trace"] = not build
 
         config["LayerName"]["jet_id_output"]["Precision"]["result"] = self.firmware_config['class_precision']
-        config["LayerName"]["jet_id_output"]["Implementation"] = "latency"
+        config["LayerName"]["jet_id_output"]["Implementation"] = "stable"
         config["LayerName"]["pT_output"]["Precision"]["result"] = self.firmware_config['reg_precision']
         config["LayerName"]["pT_output"]["Implementation"] = "latency"
 

--- a/tagger/model/DeepSetModel.py
+++ b/tagger/model/DeepSetModel.py
@@ -192,7 +192,7 @@ class DeepSetModel(QKerasModel):
         config["LayerName"]["Dense_3_jetID"]["Precision"]["result"] = self.firmware_config['input_precision']
         config["LayerName"]["jet_id_output"]["Precision"]["result"] = self.firmware_config['class_precision']
         config["LayerName"]["jet_id_output"]["Implementation"] = "stable"
-        config['LayerName"]["jet_id_output"]["TableSize"] = 2048
+        config["LayerName"]["jet_id_output"]["TableSize"] = 2048
         config["LayerName"]["pT_output"]["Precision"]["result"] = self.firmware_config['reg_precision']
         config["LayerName"]["pT_output"]["Implementation"] = "latency"
 

--- a/tagger/model/DeepSetModel.py
+++ b/tagger/model/DeepSetModel.py
@@ -190,7 +190,7 @@ class DeepSetModel(QKerasModel):
                 config["LayerName"][layer.name]["Trace"] = not build
 
         config["LayerName"]["jet_id_output"]["Precision"]["result"] = self.firmware_config['class_precision']
-        config["LayerName"]["jet_id_output"]["Implementation"] = "stable"
+        config["LayerName"]["jet_id_output"]["Implementation"] = "latency"
         config["LayerName"]["pT_output"]["Precision"]["result"] = self.firmware_config['reg_precision']
         config["LayerName"]["pT_output"]["Implementation"] = "latency"
 

--- a/tagger/plot/basic.py
+++ b/tagger/plot/basic.py
@@ -178,7 +178,7 @@ def ROC_binary(y_pred, y_test, class_labels, plot_dir, class_pair, signal_proc=N
 def ROC(y_pred, y_test, class_labels, plot_dir, ROC_dict):
     # Create a colormap for unique colors
     # Use 'tab10' with enough colors
-    colormap = cm.get_cmap('Set1', len(class_labels))
+    colormap = plt.get_cmap('Set1', len(class_labels))
 
     # Create a plot for ROC curves
     fig, ax = plt.subplots(1, 1, figsize=style.FIGURE_SIZE)
@@ -655,7 +655,7 @@ def shapPlot(shap_values, feature_names, class_names):
     axis_color = "#333333"
     class_inds = np.argsort([-np.abs(shap_values[i]).mean() for i in range(len(shap_values))])
     # Use 'tab10' with enough colors
-    colormap = cm.get_cmap('Set1', len(class_names))
+    colormap = plt.get_cmap('Set1', len(class_names))
 
     for i, ind in enumerate(class_inds):
         global_shap_values = np.abs(shap_values[ind]).mean(0)


### PR DESCRIPTION
Updates the pipeline to use the most up to date CMSSW 17 branch with various fixed to the scripts to allow for this
Other minor updates include:
 - Better selection of runners
 - Minor fixes for updates hls4ml and other packages in the build image
 - Fixes to the rerun on tag scripts and uploading

This branch now only runs  a pipeline on the most recently tagged model v1.0.1 and does not perform a new retraining